### PR TITLE
handle trailing <br> in the WHOIS Server line

### DIFF
--- a/build-whois.sh
+++ b/build-whois.sh
@@ -9,7 +9,7 @@
 echo "- Building whois.conf ..."
 
 for item in $(find cache/ -name '*.html' | sed 's/\.html//g;s~cache/~~g'); do
-    MYWHOIS=$(grep -E -a -i 'Whois Server' "cache/${item}.html" | cut -d\> -f3)
+    MYWHOIS=$(grep -E -a -i 'Whois Server' "cache/${item}.html" | cut -d\> -f3  | cut -d'<' -f1)
     if [ -n "${MYWHOIS}" ]; then
         echo "\.${item}\$${MYWHOIS}"
     fi


### PR DESCRIPTION
Thanks for this cool project!

It appears that newer HTMLs now have a trailing `<br>` in the "WHOIS Server" line that the current parser does not expect.

Fixed it by adding another `cut` looking for the start of an HTML tag.

An example of the newer HTML format:
```
    <p>
    
        <b>URL for registration services:</b> <a href="http://www.verisigninc.com">http://www.verisigninc.com</a><br/>
    
    
        <b>WHOIS Server:</b> whois.verisign-grs.com <br>
    
    
        <b>RDAP Server: </b> https://rdap.verisign.com/com/v1/
    
    </p>
```